### PR TITLE
Add highlights to support indent blankline version 3

### DIFF
--- a/lua/night-owl/theme.lua
+++ b/lua/night-owl/theme.lua
@@ -195,7 +195,6 @@ theme.set_highlights = function()
   hl(0, "IblWhitespace", { link = 'IndentChar' })
   hl(0, "IblScope", { link = 'IndentCharActive' })
 
-
   -- Dashboard
 
   -- Cmp

--- a/lua/night-owl/theme.lua
+++ b/lua/night-owl/theme.lua
@@ -60,6 +60,7 @@ theme.set_highlights = function()
   hl(0, "Delimiter", { fg = c.fg, bg = 'NONE' })
   hl(0, "Error", { fg = c.error_red, bg = 'NONE' })
   hl(0, "IndentChar", { fg = c.indent_guide, bg = 'NONE' })
+  hl(0, "IndentCharActive", { fg = c.indent_guide_active, bg = 'NONE' })
   hl(0, "IndentContextChar", { fg = c.magenta3, bg = 'NONE' })
   hl(0, "TabLineSel", { fg = c.gray2, bg = c.tab_active_bg })
   hl(0, "TabLine", { fg = c.ui_border, bg = c.tab_inactive_bg })
@@ -188,6 +189,12 @@ theme.set_highlights = function()
   hl(0, "IndentBlanklineSpaceCharBlankline", { link = 'IndentChar' })
   hl(0, "IndentBlanklineContextChar", { link = 'IndentContextChar' })
   hl(0, "IndentBlanklineContextStart", { fg = 'NONE', bg = 'NONE', sp = c.indent_guide, underline=true, })
+
+  -- IndentBlankline v3
+  hl(0, "IblIndent", { link = 'IndentChar' })
+  hl(0, "IblWhitespace", { link = 'IndentChar' })
+  hl(0, "IblScope", { link = 'IndentCharActive' })
+
 
   -- Dashboard
 


### PR DESCRIPTION
Thank you so much for porting over night owl! I was excited to see that y'all have support for indent blankline, but I noticed that it didn't work with version three of the plugin. This PR should fix that!

One thing I don't know is what y'all wanted the context scope to look like. I've attached a screen shot below — let me know if any of the colors need updating!

Screenshot: 
<img width="697" alt="Screen Shot 2023-11-11 at 9 14 22 AM" src="https://github.com/oxfist/night-owl.nvim/assets/19441026/22e55120-6a5f-4b93-a04e-3ca0a8b6130a">
