### PR TITLE
Add support for nvim-cmp suggestions

### DIFF
--- a/lua/night-owl/theme.lua
+++ b/lua/night-owl/theme.lua
@@ -268,6 +268,24 @@ function theme.set_highlights(options)
 	-- Set the terminal background and foreground colors
 	hl(0, "Terminal", { fg = palette.fg, bg = palette.bg })
 
+    -- nvim-cmp
+    hl(0, "CmpItemAbbr", { fg = palette.fg, bg = "NONE", })
+    hl(0, "CmpItemAbbrMatch", { fg = palette.blue, bold = true })
+    hl(0, "CmpItemAbbrMatchFuzzy", { fg = palette.blue, bold = true })
+    hl(0, "CmpItemKindFunction", { fg = palette.blue, bg = "NONE", })
+    hl(0, "CmpItemKindMethod", { fg = palette.blue, bg = "NONE", })
+    hl(0, "CmpItemKindVariable", { fg = palette.orange, bg = "NONE", })
+    hl(0, "CmpItemKindProperty", { fg = palette.orange, bg = "NONE", })
+    hl(0, "CmpItemKindKeyword", { fg = palette.magenta, bg = "NONE", })
+    hl(0, "CmpItemKindSnippet", { fg = palette.magenta, bg = "NONE", })
+    hl(0, "CmpItemKindOperator", { fg = palette.magenta, bg = "NONE", })
+    hl(0, "CmpItemKindInterface", { fg = palette.cyan2, bg = "NONE", })
+    hl(0, "CmpItemKindStruct", { fg = palette.cyan2, bg = "NONE", })
+    hl(0, "CmpItemKindEnum", { fg = palette.cyan2, bg = "NONE", })
+    hl(0, "CmpItemKindModule", { fg = palette.fg, bg = "NONE", })
+    hl(0, "CmpItemKindFile", { fg = palette.fg, bg = "NONE", })
+    hl(0, "CmpItemKindFolder", { fg = palette.fg, bg = "NONE", })
+
 	-- Terminal colors
 	vim.g.terminal_color_0 = palette.dark -- Black
 	vim.g.terminal_color_1 = palette.dark_red -- Red


### PR DESCRIPTION
Add highlight group definitions for the nvim-cmp highlight groups.

![image](https://github.com/user-attachments/assets/321ad862-8fd2-4af3-ade3-351b1d91cc37)
![image](https://github.com/user-attachments/assets/8f8d7d31-4a25-45f4-af89-19561967fcd3)

